### PR TITLE
Support Glamsterdam HF 

### DIFF
--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -8,10 +8,10 @@ resolver = "2"
 ethereum-consensus = { path = "../../crates/consensus", default-features = false }
 ethereum-light-client-verifier = { path = "../../crates/light-client-verifier", default-features = false }
 
-sp-core = { version = "18.0.0", default-features = false, optional = true }
-sp-io = { version = "20.0.0", default-features = false, optional = true }
-sp-runtime = { version = "21.0.0", default-features = false, optional = true }
-sp-std = { version = "7.0.0", default-features = false, optional = true }
+sp-core = { version = "34.0.0", default-features = false, optional = true }
+sp-io = { version = "38.0.0", default-features = false, optional = true }
+sp-runtime = { version = "39.0.0", default-features = false, optional = true }
+sp-std = { version = "14.0.0", default-features = false, optional = true }
 
 [features]
 panic-handler = []

--- a/ci/no-std-check/src/lib.rs
+++ b/ci/no-std-check/src/lib.rs
@@ -43,7 +43,6 @@ error[E0152]: found duplicate lang item `panic_impl`
  */
 #[cfg(feature = "panic-handler")]
 #[panic_handler]
-#[no_mangle]
 fn panic(_info: &PanicInfo) -> ! {
     loop {}
 }

--- a/crates/consensus/src/fork.rs
+++ b/crates/consensus/src/fork.rs
@@ -3,6 +3,7 @@ pub mod bellatrix;
 pub mod capella;
 pub mod deneb;
 pub mod electra;
+pub mod gloas;
 
 use crate::beacon::{Epoch, Slot, Version};
 use crate::errors::Error;
@@ -16,12 +17,15 @@ pub const GENESIS_SPEC: ForkSpec = ForkSpec {
     execution_payload_gindex: 0,
     execution_payload_state_root_gindex: 0,
     execution_payload_block_number_gindex: 0,
+    execution_block_hash_gindex: 0,
 };
 
 pub const ALTAIR_INDEX: usize = 0;
 pub const BELLATRIX_INDEX: usize = 1;
 pub const CAPELLA_INDEX: usize = 2;
 pub const DENEB_INDEX: usize = 3;
+pub const ELECTRA_INDEX: usize = 4;
+pub const GLOAS_INDEX: usize = 5;
 
 /// Fork parameters for the beacon chain
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -113,6 +117,17 @@ pub struct ForkSpec {
     pub execution_payload_state_root_gindex: u32,
     /// get_generalized_index(ExecutionPayload, 'block_number')
     pub execution_payload_block_number_gindex: u32,
+    /// get_generalized_index(BeaconBlockBody, 'signed_execution_payload_bid', 'message', 'parent_block_hash')
+    /// This is used for Gloas and later forks where LightClientHeader contains execution_block_hash instead of ExecutionPayloadHeader
+    pub execution_block_hash_gindex: u32,
+}
+
+impl ForkSpec {
+    /// Returns true if this is Gloas or later fork
+    /// Gloas uses execution_block_hash instead of ExecutionPayloadHeader in LightClientHeader
+    pub fn is_gloas(&self) -> bool {
+        self.execution_block_hash_gindex > 0
+    }
 }
 
 /// Fork parameters for each fork

--- a/crates/consensus/src/fork/gloas.rs
+++ b/crates/consensus/src/fork/gloas.rs
@@ -1,4 +1,4 @@
-use super::{electra, ForkSpec};
+use super::ForkSpec;
 use crate::{
     beacon::{BeaconBlockHeader, Slot},
     internal_prelude::*,
@@ -6,18 +6,26 @@ use crate::{
     types::H256,
 };
 
-/// https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/light-client/sync-protocol.md
-/// EXECUTION_BLOCK_HASH_GINDEX_GLOAS = 832
+/// https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/light-client/sync-protocol.md#new-constants
+/// EIP-7688 turns BeaconState into a progressive container, so the state gindices
+/// are not inherited from Electra; EIP-7732 moves the execution commitment into
+/// signed_execution_payload_bid, which gives a new block body gindex.
 pub const GLOAS_FORK_SPEC: ForkSpec = ForkSpec {
+    // FINALIZED_ROOT_GINDEX_GLOAS
+    finalized_root_gindex: 735,
+    // CURRENT_SYNC_COMMITTEE_GINDEX_GLOAS
+    current_sync_committee_gindex: 2945,
+    // NEXT_SYNC_COMMITTEE_GINDEX_GLOAS
+    next_sync_committee_gindex: 2946,
     // Gloas uses execution_block_hash_gindex instead of execution_payload_gindex
     // The merkle proof verifies execution_block_hash (not hash_tree_root(execution)) against body_root
     execution_payload_gindex: 0,
-    // execution_payload_state_root_gindex and execution_payload_block_number_gindex are inherited
-    // from ELECTRA_FORK_SPEC (which inherits from DENEB) for ExecutionPayloadHeader verification
-    // EXECUTION_BLOCK_HASH_GINDEX_GLOAS = 832
+    // Not used in Gloas (RLP verification instead of SSZ merkle proofs)
+    execution_payload_state_root_gindex: 0,
+    execution_payload_block_number_gindex: 0,
+    // EXECUTION_BLOCK_HASH_GINDEX_GLOAS = 2856
     // get_generalized_index(BeaconBlockBody, 'signed_execution_payload_bid', 'message', 'parent_block_hash')
-    execution_block_hash_gindex: 832,
-    ..electra::ELECTRA_FORK_SPEC
+    execution_block_hash_gindex: 2856,
 };
 
 /// LightClientHeader for Gloas (spec-compliant)

--- a/crates/consensus/src/fork/gloas.rs
+++ b/crates/consensus/src/fork/gloas.rs
@@ -1,0 +1,66 @@
+use super::{electra, ForkSpec};
+use crate::{
+    beacon::{BeaconBlockHeader, Slot},
+    internal_prelude::*,
+    sync_protocol::{SyncAggregate, SyncCommittee},
+    types::H256,
+};
+
+/// https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/light-client/sync-protocol.md
+/// EXECUTION_BLOCK_HASH_GINDEX_GLOAS = 832
+pub const GLOAS_FORK_SPEC: ForkSpec = ForkSpec {
+    // Gloas uses execution_block_hash_gindex instead of execution_payload_gindex
+    // The merkle proof verifies execution_block_hash (not hash_tree_root(execution)) against body_root
+    execution_payload_gindex: 0,
+    // execution_payload_state_root_gindex and execution_payload_block_number_gindex are inherited
+    // from ELECTRA_FORK_SPEC (which inherits from DENEB) for ExecutionPayloadHeader verification
+    // EXECUTION_BLOCK_HASH_GINDEX_GLOAS = 832
+    // get_generalized_index(BeaconBlockBody, 'signed_execution_payload_bid', 'message', 'parent_block_hash')
+    execution_block_hash_gindex: 832,
+    ..electra::ELECTRA_FORK_SPEC
+};
+
+/// LightClientHeader for Gloas (spec-compliant)
+/// https://github.com/ethereum/consensus-specs/blob/dev/specs/gloas/light-client/sync-protocol.md
+///
+/// Unlike previous forks, Gloas LightClientHeader contains only execution_block_hash
+/// instead of the full ExecutionPayloadHeader. The client must fetch ExecutionPayloadHeader
+/// from the Execution Layer using this hash.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LightClientHeader {
+    /// Header matching the requested beacon block root
+    pub beacon: BeaconBlockHeader,
+    /// Execution block hash (signed_execution_payload_bid.message.parent_block_hash)
+    pub execution_block_hash: H256,
+    /// Merkle branch proving execution_block_hash within BeaconBlockBody
+    pub execution_branch: Vec<H256>,
+}
+
+/// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md#lightclientbootstrap
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LightClientBootstrap<const SYNC_COMMITTEE_SIZE: usize> {
+    pub header: LightClientHeader,
+    /// Current sync committee corresponding to `beacon_header.state_root`
+    pub current_sync_committee: SyncCommittee<SYNC_COMMITTEE_SIZE>,
+    pub current_sync_committee_branch: Vec<H256>,
+}
+
+/// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md#lightclientupdate
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct LightClientUpdate<const SYNC_COMMITTEE_SIZE: usize> {
+    /// Header attested to by the sync committee
+    pub attested_header: LightClientHeader,
+    /// Next sync committee corresponding to `attested_header.state_root`
+    pub next_sync_committee: Option<(SyncCommittee<SYNC_COMMITTEE_SIZE>, Vec<H256>)>,
+    /// Finalized header corresponding to `attested_header.state_root`
+    pub finalized_header: LightClientHeader,
+    pub finality_branch: Vec<H256>,
+    /// Sync committee aggregate signature
+    pub sync_aggregate: SyncAggregate<SYNC_COMMITTEE_SIZE>,
+    /// Slot at which the aggregate signature was created (untrusted)
+    pub signature_slot: Slot,
+}
+
+/// Re-export ExecutionPayloadHeader from deneb for client use
+/// Client fetches this from EL using execution_block_hash
+pub use super::deneb::ExecutionPayloadHeader;

--- a/crates/consensus/src/merkle.rs
+++ b/crates/consensus/src/merkle.rs
@@ -78,6 +78,6 @@ pub const fn get_subtree_index(gindex: u32) -> u32 {
 
 fn hash(bz: Vec<u8>) -> H256 {
     let mut output = H256::default();
-    output.0.copy_from_slice(Sha256::digest(bz).as_slice());
+    output.0.copy_from_slice(Sha256::digest(bz).as_ref());
     output
 }

--- a/crates/light-client-verifier/Cargo.toml
+++ b/crates/light-client-verifier/Cargo.toml
@@ -19,6 +19,7 @@ rand = { version = "0.8.5", features = ["std", "std_rng"], optional = true}
 serde_json = "1.0.91"
 hex-literal = "0.3.4"
 rand = { version = "0.8.5", features = ["std", "std_rng"] }
+sha2 = { version = "0.10.2" }
 ethereum-consensus = { path = "../consensus", default-features = false, features = ["prover"] }
 
 [features]

--- a/crates/light-client-verifier/src/consensus.rs
+++ b/crates/light-client-verifier/src/consensus.rs
@@ -2113,4 +2113,218 @@ mod tests {
             }
         }
     }
+    mod gloas {
+        use crate::{
+            consensus::{
+                validate_execution_rlp, SyncProtocolVerifier, RLP_BLOCK_NUMBER_INDEX,
+                RLP_STATE_ROOT_INDEX,
+            },
+            context::{Fraction, LightClientContext},
+            errors::Error,
+            mock::MockStore,
+            updates::{bellatrix::ConsensusUpdateInfo, ConsensusUpdate, ExecutionUpdate},
+        };
+        use ethereum_consensus::{
+            beacon::Version,
+            fork::{deneb::DENEB_FORK_SPEC, gloas::GLOAS_FORK_SPEC, ForkParameter, ForkParameters},
+            merkle::{get_depth, get_subtree_index},
+            preset,
+            types::{H256, U64},
+        };
+        use patricia_merkle_trie::keccak::keccak_256;
+        use sha2::{Digest, Sha256};
+
+        const SYNC_COMMITTEE_SIZE: usize = preset::minimal::PRESET.SYNC_COMMITTEE_SIZE;
+
+        fn h256(b: u8) -> H256 {
+            H256::from_slice(&[b; 32])
+        }
+
+        fn sha256_concat(l: &H256, r: &H256) -> H256 {
+            let mut output = H256::default();
+            output
+                .0
+                .copy_from_slice(Sha256::digest([l.as_bytes(), r.as_bytes()].concat()).as_ref());
+            output
+        }
+
+        /// Build a minimal RLP-encoded execution block header whose
+        /// state_root/block_number fields decode to the given values
+        fn build_rlp_header(state_root: H256, block_number: u64) -> Vec<u8> {
+            let mut stream = rlp::RlpStream::new_list(12);
+            for i in 0..12 {
+                if i == RLP_STATE_ROOT_INDEX {
+                    stream.append(&state_root.as_bytes().to_vec());
+                } else if i == RLP_BLOCK_NUMBER_INDEX {
+                    stream.append(&block_number);
+                } else {
+                    stream.append(&vec![0u8; 32]);
+                }
+            }
+            stream.out().to_vec()
+        }
+
+        #[test]
+        fn test_validate_execution_rlp() {
+            let state_root = h256(9);
+            let block_number = U64(12345);
+            let rlp_bytes = build_rlp_header(state_root, block_number.0);
+            let block_hash: H256 = keccak_256(&rlp_bytes).into();
+
+            // valid
+            validate_execution_rlp(&rlp_bytes, block_hash, state_root, block_number).unwrap();
+
+            // block hash mismatch
+            assert!(matches!(
+                validate_execution_rlp(&rlp_bytes, h256(1), state_root, block_number),
+                Err(Error::ExecutionBlockHashMismatch(..))
+            ));
+
+            // state root mismatch
+            assert!(matches!(
+                validate_execution_rlp(&rlp_bytes, block_hash, h256(2), block_number),
+                Err(Error::ExecutionStateRootMismatch(..))
+            ));
+
+            // block number mismatch
+            assert!(matches!(
+                validate_execution_rlp(&rlp_bytes, block_hash, state_root, U64(1)),
+                Err(Error::ExecutionBlockNumberMismatch(..))
+            ));
+
+            // invalid RLP
+            let garbage = vec![0xff, 0x00, 0x01];
+            let garbage_hash: H256 = keccak_256(&garbage).into();
+            assert!(matches!(
+                validate_execution_rlp(&garbage, garbage_hash, state_root, block_number),
+                Err(Error::InvalidExecutionBlockHeaderRlp)
+            ));
+
+            // too few fields
+            let mut stream = rlp::RlpStream::new_list(5);
+            for _ in 0..5 {
+                stream.append(&vec![0u8; 32]);
+            }
+            let short = stream.out().to_vec();
+            let short_hash: H256 = keccak_256(&short).into();
+            assert!(matches!(
+                validate_execution_rlp(&short, short_hash, state_root, block_number),
+                Err(Error::InvalidExecutionBlockHeaderRlp)
+            ));
+        }
+
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        struct TestExecutionUpdate {
+            state_root: H256,
+            block_number: U64,
+            rlp: Vec<u8>,
+        }
+
+        impl ExecutionUpdate for TestExecutionUpdate {
+            fn state_root(&self) -> H256 {
+                self.state_root
+            }
+            fn state_root_branch(&self) -> Vec<H256> {
+                Vec::new()
+            }
+            fn block_number(&self) -> U64 {
+                self.block_number
+            }
+            fn block_number_branch(&self) -> Vec<H256> {
+                Vec::new()
+            }
+            fn rlp(&self) -> Vec<u8> {
+                self.rlp.clone()
+            }
+        }
+
+        #[test]
+        fn test_validate_execution_update_gloas_dispatch() {
+            let verifier = SyncProtocolVerifier::<
+                SYNC_COMMITTEE_SIZE,
+                MockStore<SYNC_COMMITTEE_SIZE>,
+            >::default();
+            let state_root = h256(9);
+            let block_number = U64(12345);
+            let rlp_bytes = build_rlp_header(state_root, block_number.0);
+            let block_hash: H256 = keccak_256(&rlp_bytes).into();
+
+            // Gloas: RLP verification path
+            let update = TestExecutionUpdate {
+                state_root,
+                block_number,
+                rlp: rlp_bytes,
+            };
+            verifier
+                .validate_execution_update(GLOAS_FORK_SPEC, block_hash, &update)
+                .unwrap();
+
+            // pre-Gloas: merkle proof path requires non-empty branches
+            let pre_gloas = TestExecutionUpdate {
+                state_root,
+                block_number,
+                rlp: Vec::new(),
+            };
+            assert!(verifier
+                .validate_execution_update(DENEB_FORK_SPEC, block_hash, &pre_gloas)
+                .is_err());
+        }
+
+        fn gloas_context() -> LightClientContext {
+            LightClientContext::new(
+                ForkParameters::new(
+                    Version([8, 0, 0, 1]),
+                    vec![ForkParameter::new(
+                        Version([8, 0, 0, 1]),
+                        U64(0),
+                        GLOAS_FORK_SPEC,
+                    )],
+                )
+                .unwrap(),
+                preset::minimal::PRESET.SECONDS_PER_SLOT,
+                preset::minimal::PRESET.SLOTS_PER_EPOCH,
+                preset::minimal::PRESET.EPOCHS_PER_SYNC_COMMITTEE_PERIOD,
+                U64(0),
+                Default::default(),
+                preset::minimal::PRESET.MIN_SYNC_COMMITTEE_PARTICIPANTS,
+                Fraction::new(2, 3).unwrap(),
+                U64(0),
+            )
+        }
+
+        #[test]
+        fn test_gloas_finalized_header_verification() {
+            // build a merkle branch for execution_block_hash at
+            // EXECUTION_BLOCK_HASH_GINDEX_GLOAS within body_root
+            let gindex = GLOAS_FORK_SPEC.execution_block_hash_gindex;
+            let depth = get_depth(gindex);
+            let subtree_index = get_subtree_index(gindex);
+            let execution_block_hash = h256(7);
+            let branch: Vec<H256> = (1..=depth as u8).map(h256).collect();
+            let mut body_root = execution_block_hash;
+            for (i, b) in branch.iter().enumerate() {
+                let v = 2u32.pow(i as u32);
+                body_root = if subtree_index / v % 2 == 1 {
+                    sha256_concat(b, &body_root)
+                } else {
+                    sha256_concat(&body_root, b)
+                };
+            }
+
+            let mut update = ConsensusUpdateInfo::<SYNC_COMMITTEE_SIZE>::default();
+            update.light_client_update.finalized_header.0.body_root = body_root;
+            update.finalized_execution_root = execution_block_hash;
+            update.finalized_execution_branch = branch;
+
+            let ctx = gloas_context();
+            update.is_valid_light_client_finalized_header(&ctx).unwrap();
+
+            // tampered execution block hash must be rejected
+            let mut tampered = update.clone();
+            tampered.finalized_execution_root = h256(0xee);
+            assert!(tampered
+                .is_valid_light_client_finalized_header(&ctx)
+                .is_err());
+        }
+    }
 }

--- a/crates/light-client-verifier/src/consensus.rs
+++ b/crates/light-client-verifier/src/consensus.rs
@@ -15,7 +15,8 @@ use ethereum_consensus::context::ChainContext;
 use ethereum_consensus::fork::{ForkSpec, BELLATRIX_INDEX};
 use ethereum_consensus::merkle::is_valid_normalized_merkle_branch;
 use ethereum_consensus::sync_protocol::SyncCommittee;
-use ethereum_consensus::types::H256;
+use ethereum_consensus::types::{H256, U64};
+use patricia_merkle_trie::keccak::keccak_256;
 
 /// SyncProtocolVerifier is a verifier of [light client sync protocol](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/sync-protocol.md)
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -108,32 +109,21 @@ impl<const SYNC_COMMITTEE_SIZE: usize, ST: LightClientStoreReader<SYNC_COMMITTEE
         execution_update: &EU,
     ) -> Result<(), Error> {
         execution_update.validate_basic()?;
-        if update_fork_spec.execution_payload_gindex == 0 {
-            return Err(Error::NoExecutionPayloadInBeaconBlock);
+        let rlp = execution_update.rlp();
+        if update_fork_spec.is_gloas() {
+            validate_execution_rlp(
+                &rlp,
+                trusted_execution_root,
+                execution_update.state_root(),
+                execution_update.block_number(),
+            )
+        } else {
+            validate_execution_merkle_proofs(
+                update_fork_spec,
+                trusted_execution_root,
+                execution_update,
+            )
         }
-        is_valid_normalized_merkle_branch(
-            hash_tree_root(execution_update.state_root())
-                .unwrap()
-                .0
-                .into(),
-            &execution_update.state_root_branch(),
-            update_fork_spec.execution_payload_state_root_gindex,
-            trusted_execution_root,
-        )
-        .map_err(Error::InvalidExecutionStateRootMerkleBranch)?;
-
-        is_valid_normalized_merkle_branch(
-            hash_tree_root(execution_update.block_number())
-                .unwrap()
-                .0
-                .into(),
-            &execution_update.block_number_branch(),
-            update_fork_spec.execution_payload_block_number_gindex,
-            trusted_execution_root,
-        )
-        .map_err(Error::InvalidExecutionBlockNumberMerkleBranch)?;
-
-        Ok(())
     }
 
     /// validates a misbehaviour with the store.
@@ -174,6 +164,105 @@ impl<const SYNC_COMMITTEE_SIZE: usize, ST: LightClientStoreReader<SYNC_COMMITTEE
             ))
         }
     }
+}
+
+/// RLP field indices for execution block header
+/// Based on the original Frontier block header layout.
+const RLP_STATE_ROOT_INDEX: usize = 3;
+const RLP_BLOCK_NUMBER_INDEX: usize = 8;
+
+/// Validate execution update using RLP block hash (Gloas+)
+fn validate_execution_rlp(
+    rlp: &[u8],
+    trusted_execution_root: Root,
+    expected_state_root: H256,
+    expected_block_number: U64,
+) -> Result<(), Error> {
+    // Verify keccak256(rlp) == execution_block_hash
+    let block_hash: H256 = keccak_256(rlp).into();
+    if block_hash != trusted_execution_root {
+        return Err(Error::ExecutionBlockHashMismatch(
+            trusted_execution_root,
+            block_hash,
+        ));
+    }
+
+    // Verify state_root and block_number match the RLP-decoded values
+    let (state_root, block_number) = decode_rlp_header_fields(rlp)?;
+    if expected_state_root != state_root {
+        return Err(Error::ExecutionStateRootMismatch(
+            state_root,
+            expected_state_root,
+        ));
+    }
+    if expected_block_number != block_number {
+        return Err(Error::ExecutionBlockNumberMismatch(
+            block_number,
+            expected_block_number,
+        ));
+    }
+    Ok(())
+}
+
+/// Decode state_root and block_number from RLP-encoded execution block header
+fn decode_rlp_header_fields(rlp_bytes: &[u8]) -> Result<(H256, U64), Error> {
+    let rlp = rlp::Rlp::new(rlp_bytes);
+    let min_count = RLP_STATE_ROOT_INDEX.max(RLP_BLOCK_NUMBER_INDEX) + 1;
+    if rlp
+        .item_count()
+        .map_err(|_| Error::InvalidExecutionBlockHeaderRlp)?
+        < min_count
+    {
+        return Err(Error::InvalidExecutionBlockHeaderRlp);
+    }
+    let state_root = decode_h256(&rlp, RLP_STATE_ROOT_INDEX)?;
+    let block_number = decode_u64(&rlp, RLP_BLOCK_NUMBER_INDEX)?;
+    Ok((state_root, block_number))
+}
+
+fn decode_h256(rlp: &rlp::Rlp, index: usize) -> Result<H256, Error> {
+    let bytes: Vec<u8> = rlp
+        .val_at(index)
+        .map_err(|_| Error::InvalidExecutionBlockHeaderRlp)?;
+    if bytes.len() != 32 {
+        return Err(Error::InvalidExecutionBlockHeaderRlp);
+    }
+    Ok(H256::from_slice(&bytes))
+}
+
+fn decode_u64(rlp: &rlp::Rlp, index: usize) -> Result<U64, Error> {
+    let bytes: Vec<u8> = rlp
+        .val_at(index)
+        .map_err(|_| Error::InvalidExecutionBlockHeaderRlp)?;
+    Ok(U64(bytes
+        .iter()
+        .fold(0u64, |acc, &b| (acc << 8) | b as u64)))
+}
+
+/// Validate execution update using SSZ merkle proofs (pre-Gloas)
+fn validate_execution_merkle_proofs<EU: ExecutionUpdate>(
+    fork_spec: ForkSpec,
+    trusted_execution_root: Root,
+    update: &EU,
+) -> Result<(), Error> {
+    if fork_spec.execution_payload_gindex == 0 {
+        return Err(Error::NoExecutionPayloadInBeaconBlock);
+    }
+    is_valid_normalized_merkle_branch(
+        hash_tree_root(update.state_root()).unwrap().0.into(),
+        &update.state_root_branch(),
+        fork_spec.execution_payload_state_root_gindex,
+        trusted_execution_root,
+    )
+    .map_err(Error::InvalidExecutionStateRootMerkleBranch)?;
+    is_valid_normalized_merkle_branch(
+        hash_tree_root(update.block_number()).unwrap().0.into(),
+        &update.block_number_branch(),
+        fork_spec.execution_payload_block_number_gindex,
+        trusted_execution_root,
+    )
+    .map_err(Error::InvalidExecutionBlockNumberMerkleBranch)?;
+    Ok(())
 }
 
 /// verify a sync committee attestation

--- a/crates/light-client-verifier/src/errors.rs
+++ b/crates/light-client-verifier/src/errors.rs
@@ -89,6 +89,17 @@ pub enum Error {
     NoExecutionPayloadInBeaconBlock,
     /// invalid merkle branch of execution block number: `error={0}`
     InvalidExecutionBlockNumberMerkleBranch(MerkleError),
+    /// execution block hash mismatch: `expected={0:?} actual={1:?}`
+    ExecutionBlockHashMismatch(H256, H256),
+    /// execution state root mismatch: `header={0:?} update={1:?}`
+    ExecutionStateRootMismatch(H256, H256),
+    /// execution block number mismatch: `header={0} update={1}`
+    ExecutionBlockNumberMismatch(
+        ethereum_consensus::types::U64,
+        ethereum_consensus::types::U64,
+    ),
+    /// invalid execution block header RLP
+    InvalidExecutionBlockHeaderRlp,
     /// inconsistent next sync committee: `store:{0:?}` != `update:{1:?}`
     InconsistentNextSyncCommittee(PublicKey, PublicKey),
     /// invalid fraction: `fraction={0:?}`

--- a/crates/light-client-verifier/src/updates.rs
+++ b/crates/light-client-verifier/src/updates.rs
@@ -59,10 +59,17 @@ pub trait ConsensusUpdate<const SYNC_COMMITTEE_SIZE: usize>:
         ctx: &C,
     ) -> Result<(), Error> {
         let spec = ctx.compute_fork_spec(self.finalized_beacon_header().slot);
+        // For Gloas and later forks, use execution_block_hash_gindex
+        // For earlier forks, use execution_payload_gindex
+        let gindex = if spec.is_gloas() {
+            spec.execution_block_hash_gindex
+        } else {
+            spec.execution_payload_gindex
+        };
         is_valid_normalized_merkle_branch(
             self.finalized_execution_root(),
             &self.finalized_execution_branch(),
-            spec.execution_payload_gindex,
+            gindex,
             self.finalized_beacon_header().body_root,
         )
         .map_err(Error::InvalidFinalizedExecutionPayload)
@@ -106,13 +113,25 @@ pub trait ExecutionUpdate: core::fmt::Debug + Clone + PartialEq + Eq {
     /// `state_root` of the execution payload
     fn state_root(&self) -> H256;
     /// merkle branch of `state_root` within `ExecutionPayload`
+    /// For Gloas+, this can be empty since verification uses RLP block header
     fn state_root_branch(&self) -> Vec<H256>;
     /// `block_number` of the execution payload
     fn block_number(&self) -> U64;
     /// merkle branch of `block_number` within `ExecutionPayload`
+    /// For Gloas+, this can be empty since verification uses RLP block header
     fn block_number_branch(&self) -> Vec<H256>;
-    /// validate the basic properties of the update
+    /// RLP-encoded execution block header (for Gloas+)
+    /// Returns non-empty bytes for Gloas+, empty for pre-Gloas
+    /// When non-empty, keccak256(rlp) must equal `ConsensusUpdate.finalized_execution_root()`
+    fn rlp(&self) -> Vec<u8> {
+        Vec::new()
+    }
+    /// validate the basic properties of the update (pre-Gloas only)
+    /// For Gloas+, validation is done in validate_execution_rlp
     fn validate_basic(&self) -> Result<(), Error> {
+        if !self.rlp().is_empty() {
+            return Ok(());
+        }
         if self.state_root_branch().is_empty() {
             return Err(Error::EmptyExecutionPayloadStateRootBranch);
         }


### PR DESCRIPTION
## Summary

Support the Gloas (Glamsterdam) light client sync protocol, following the latest consensus-specs.

In Gloas, LightClientHeader no longer carries an ExecutionPayloadHeader; it carries only execution_block_hash (EIP-7732), and the BeaconState gindices change (EIP-7688). Execution values can no longer be verified with SSZ merkle proofs, so they are verified against the RLP-encoded execution block header instead.

## Changes

- ForkSpec: add execution_block_hash_gindex. A non-zero value marks Gloas and later forks (is_gloas()).
- Add fork::gloas with GLOAS_FORK_SPEC (finalized_root_gindex=735, current/next_sync_committee_gindex=2945/2946, execution_block_hash_gindex=2856) and the Gloas LightClientHeader (execution_block_hash instead of execution).
- Finalized header verification: for Gloas, verify execution_block_hash against body_root at execution_block_hash_gindex (pre-Gloas remains execution_payload_gindex).
- Execution update verification: for Gloas, verify keccak256(rlp) == execution_block_hash and that state_root / block_number match the RLP-decoded header fields. ExecutionUpdate trait gains rlp() (empty for pre-Gloas, which keeps the SSZ merkle proof path).
- Add error variants for the RLP verification (ExecutionBlockHashMismatch, ExecutionStateRootMismatch, ExecutionBlockNumberMismatch, InvalidExecutionBlockHeaderRlp).
- ci: bump sp-* in no-std-check, remove #[no_mangle] from the panic handler.
